### PR TITLE
Fix codelists

Removing empty columns, leading and trailing whitespace, extra quoting characters, and/or adding missing quoting characters, closing newline

### DIFF
--- a/codelists/riskAllocation.csv
+++ b/codelists/riskAllocation.csv
@@ -1,4 +1,4 @@
-Category,Code,Title_en,Description_en,Source
-,publicAuthority,Public authority,The risk is wholly or mostly retained by the public authority,
-,privateParty,Private party,The risk is wholly or mostly retained by the private party,
-,undefined,Undefined,The risk is not clearly assigned to a specific party. Further details can be provided in the notes field.,
+Code,Title_en,Description_en
+publicAuthority,Public authority,The risk is wholly or mostly retained by the public authority
+privateParty,Private party,The risk is wholly or mostly retained by the private party
+undefined,Undefined,The risk is not clearly assigned to a specific party. Further details can be provided in the notes field.

--- a/codelists/riskCategory.csv
+++ b/codelists/riskCategory.csv
@@ -13,6 +13,5 @@ finance,refinancing,Refinancing risks,Risks relating to the downside of refinanc
 other,changeInLaw,Changes in law,Risk that a change in general law or the sector regulatory framework adversely affect the project,APMG PPP Certification Program
 other,forceMajeure,Force Majeure,"Risk that external events beyond the control of the parties to the contract, such as natural disasters, wars, terrorism etc.,  affect the project",APMG PPP Certification Program
 other,earlyTermination,Early termination,Risk that compensation sum due to early termination may be insufficient to meet private party’s financial obligations or is less than expected,APMG PPP Certification Program
-other,"compliance
-",Compliance risks,Risks deriving from the compliance or lack thereof of regulatory obligations related to the development of the project,
+other,compliance,Compliance risks,Risks deriving from the compliance or lack thereof of regulatory obligations related to the development of the project,
 other,all,All risks,All risks deriving from the project,


### PR DESCRIPTION
open-contracting/standard-maintenance-scripts#6